### PR TITLE
Update enqueue_script and enqueue_style to use native files

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -127,12 +127,12 @@ add_action( 'widgets_init', 'flint_widgets_init' );
  */
 function flint_scripts() {
   
-  // Load Twitter Bootstrap 2.3.2
-  wp_enqueue_script( 'bootstrap', '//netdna.bootstrapcdn.com/bootstrap/3.0.0-rc1/js/bootstrap.min.js', array('jquery'), '3.0.0-rc1', true );
-  wp_enqueue_style( 'bootstrap-css', '//netdna.bootstrapcdn.com/bootstrap/3.0.0-rc1/css/bootstrap.min.css', array() , '3.0.0-rc1' );
+  // Load Twitter Bootstrap
+  wp_enqueue_script( 'bootstrap', get_template_directory_uri() . '/js/bootstrap.min.js', array('jquery'), '3.0.0-rc1', true );
+  wp_enqueue_style( 'bootstrap-css', get_template_directory_uri() . '/css/bootstrap.min.css', array() , '3.0.0-rc1' );
   
-  //Load Font Awesome 3.1.1
-  wp_enqueue_style( 'font-awesome', '//netdna.bootstrapcdn.com/font-awesome/3.2.0/css/font-awesome.css', array(), '3.2.0' );
+  //Load Font Awesome
+  wp_enqueue_style( 'font-awesome', get_template_directory_uri() . '/css/font-awesome.css', array('bootstrap-css'), '3.2.1' );
 
   wp_enqueue_script( 'flint-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20130115', true );
 
@@ -153,7 +153,7 @@ function flint_scripts() {
 add_action( 'wp_enqueue_scripts', 'flint_scripts' );
 
 function flint_admin_scripts() {
-  wp_enqueue_style( 'flint-admin', get_template_directory_uri() . '/css/flint-admin.css', array(), '3.0.0' );
+  wp_enqueue_style( 'flint-admin', get_template_directory_uri() . '/css/flint-admin.css', array(), '1.0.0-rc3' );
 }
 add_action( 'admin_enqueue_scripts', 'flint_admin_scripts' );
 


### PR DESCRIPTION
CDNs removed because they are not allowed in WordPress Themes
