### PR TITLE
Flint 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+###Flint 1.4.2
+- Add support for theme translation to `flint_trigger_error` function
+
 ###Flint 1.4.1
 - Replace all instances of `flint_post_thumbnail` with `flint_the_post_thumbnail`
 - Update `screenshot.png` for Flint 1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+###Flint 1.4.3
+- Replace `flint_trigger_error` with `flint_deprecated_function`
+
 ###Flint 1.4.2
 - Add support for theme translation to `flint_trigger_error` function
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Flint 1.4.2
+Flint 1.4.3
 =====
 A responsive, minimalist theme built on Twitter's Bootstrap 3 and based on Automattic's _s theme. Make it your own with a custom background, custom header, custom menus, custom colors and more.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Flint 1.4.1
+Flint 1.4.2
 =====
 A responsive, minimalist theme built on Twitter's Bootstrap 3 and based on Automattic's _s theme. Make it your own with a custom background, custom header, custom menus, custom colors and more.
 

--- a/inc/deprecated.php
+++ b/inc/deprecated.php
@@ -3,7 +3,7 @@
  * Deprecated functions for backwards compatibility
  *
  * @package Flint
- * @since 1.4.0
+ * @since 1.4.2
  */
 
 /**

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://sparks.starverte.com/flint
 Author: Star Verte LLC
 Author URI: http://starverte.com
 Description: A responsive, minimalist theme built on Twitter's Bootstrap 3 and based on Automattic's _s theme. Make it your own with a custom background, custom header, custom menus, custom colors and more.
-Version: 1.4.1
+Version: 1.4.2
 License: GPLv3
 License URI: LICENSE.md
 Tags: custom-background, custom-header, custom-menu, flexible-header, one-column, post-formats, threaded-comments, translation-ready

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://sparks.starverte.com/flint
 Author: Star Verte LLC
 Author URI: http://starverte.com
 Description: A responsive, minimalist theme built on Twitter's Bootstrap 3 and based on Automattic's _s theme. Make it your own with a custom background, custom header, custom menus, custom colors and more.
-Version: 1.4.2
+Version: 1.4.3
 License: GPLv3
 License URI: LICENSE.md
 Tags: custom-background, custom-header, custom-menu, flexible-header, one-column, post-formats, threaded-comments, translation-ready


### PR DESCRIPTION
- Replace `flint_trigger_error` with `flint_deprecated_function` (based on `_deprecated_function`)